### PR TITLE
adding default posts to localposts

### DIFF
--- a/src/components/YourFeed.tsx
+++ b/src/components/YourFeed.tsx
@@ -307,17 +307,33 @@ export class YourFeed extends React.PureComponent<DispatchProps & StateProps, Yo
                             marginTop: 0,
                         }}
                     >
-                        {post.images.map((image, index) =>
-                            <Image
-                                key={image.uri + index}
-                                source={{
-                                    uri: this.getImageUri(image),
-                                }}
-                                style={{
-                                    width: WindowWidth,
-                                    height: WindowWidth,
-                                }}
-                            />
+                        {post.images.map((image, index) => {
+                            if (image.uri.startsWith('../../images/addrss.gif')) {
+                                return (
+                                    <Image
+                                        key={image.uri + index}
+                                        source={require('../../images/addrss.gif')}
+                                        style={{
+                                            maxWidth: 320,
+                                            height: 568,
+                                        }}
+                                    />
+                                );
+                            } else {
+                                return (
+                                    <Image
+                                        key={image.uri + index}
+                                        source={{
+                                            uri: this.getImageUri(image),
+                                        }}
+                                        style={{
+                                            width: WindowWidth,
+                                            height: WindowWidth,
+                                        }}
+                                    />
+                                );
+                            }
+                        }
                         )}
                         { post.text === '' ||
                             <Markdown style={styles.markdownStyle}>{post.text}</Markdown>

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -43,6 +43,45 @@ const defaultAuthor: Author = {
     faviconUri: '',
 };
 
+const onboardingAuthor = {
+    faviconUri: '',
+    name: 'Felfele Assistant',
+    uri: '',
+};
+
+const defaultPost1: Post = {
+    _id: 0,
+    createdAt: 0,
+    images: [],
+    text: `Basic features:.
+
+Post text and images privately, and later add the posts to your public feed.
+
+Follow the public feed of others, or add your favorite RSS/Atom feeds.
+
+If you feel overwhelmed by the news, you can define your own filters in the Settings.`,
+    author: onboardingAuthor,
+};
+const defaultPost2: Post = {
+    _id: 1,
+    createdAt: 0,
+    images: [{
+        uri: '../../images/addrss.gif',
+    }],
+    text: `Adding an RSS feed`,
+    author: onboardingAuthor,
+};
+
+const defaultPost3: Post = {
+    _id: 3,
+    createdAt: 0,
+    images: [],
+    text: `You can follow others by getting an invite link from them. It can be sent on any kind of channel, or you can read your friend's QR code from his phone`,
+    author: onboardingAuthor,
+};
+
+const defaultLocalPosts = List.of(defaultPost1, defaultPost2, defaultPost3);
+
 const defaultCurrentTimestamp = 0;
 
 const defaultState: AppState = {
@@ -53,7 +92,7 @@ const defaultState: AppState = {
     author: defaultAuthor,
     currentTimestamp: defaultCurrentTimestamp,
     rssPosts: List<Post>(),
-    localPosts: List<Post>(),
+    localPosts: defaultLocalPosts,
     draft: null,
     metadata: {
         highestSeenPostId: 0,
@@ -148,7 +187,7 @@ const rssPostsReducer = (rssPosts = List<Post>(), action: Actions): List<Post> =
     return rssPosts;
 };
 
-const localPostsReducer = (localPosts = List<Post>(), action: Actions): List<Post> => {
+const localPostsReducer = (localPosts = defaultLocalPosts, action: Actions): List<Post> => {
     switch (action.type) {
         case 'ADD-POST': {
             return localPosts.insert(0, action.payload.post);

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -73,7 +73,7 @@ const defaultPost2: Post = {
 };
 
 const defaultPost3: Post = {
-    _id: 3,
+    _id: 2,
     createdAt: 0,
     images: [],
     text: `You can follow others by getting an invite link from them. It can be sent on any kind of channel, or you can read your friend's QR code from his phone`,
@@ -95,7 +95,7 @@ const defaultState: AppState = {
     localPosts: defaultLocalPosts,
     draft: null,
     metadata: {
-        highestSeenPostId: 0,
+        highestSeenPostId: 2,
     },
 };
 


### PR DESCRIPTION
3 default posts in the yourfeed, one of them contains a gif showing how to add an RSS.
#### Issues
- ugly hack to load it in EditFeed, which could be solved by a refactor of our ImageData type - instead of uri, we should store ImagePropertiesSourceOptions
- Contrary to what I said earlier, the posts are persisted, so they 'can be' / 'have to be' deleted, which is good, but there is a warning because of new posts having the same id