### PR TITLE
Added timeout to Swarm download calls

### DIFF
--- a/ios/postmodern.xcodeproj/project.pbxproj
+++ b/ios/postmodern.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };

--- a/src/Network.ts
+++ b/src/Network.ts
@@ -1,7 +1,13 @@
+import { Utils } from './Utils';
+
 export const safeFetch = async (input: RequestInfo, init?: RequestInit): Promise<Response> => {
     const response = await fetch(input, init);
     if (!response.ok) {
         throw new Error('Network error: ' + response.status);
     }
     return response;
+};
+
+export const safeFetchWithTimeout = async (input: RequestInfo, init?: RequestInit, timeout: number = 0): Promise<Response> => {
+    return await Utils.timeout(timeout, safeFetch(input, init));
 };

--- a/src/PostFeed.ts
+++ b/src/PostFeed.ts
@@ -49,10 +49,11 @@ export const updatePostFeed = async (swarmFeedApi: Swarm.FeedApi, postFeed: Post
 
 export const downloadPostFeed = async (url: string): Promise<PostFeed> => {
     try {
-        const contentHash = await Swarm.downloadFeed(url);
+        const timeout = 10000;
+        const contentHash = await Swarm.downloadFeed(url, timeout);
         Debug.log('downloadPostFeed: contentHash: ', contentHash);
 
-        const content = await Swarm.downloadData(contentHash);
+        const content = await Swarm.downloadData(contentHash, timeout);
         Debug.log('downloadPostFeed: content: ', content);
 
         const postFeed = JSON.parse(content) as PostFeed;

--- a/src/Swarm.ts
+++ b/src/Swarm.ts
@@ -4,7 +4,7 @@ import { generateSecureRandom } from 'react-native-securerandom';
 
 import { PublicIdentity, PrivateIdentity } from './models/Identity';
 import { Debug } from './Debug';
-import { safeFetch } from './Network';
+import { safeFetch, safeFetchWithTimeout } from './Network';
 
 export const DefaultGateway = 'https://swarm-gateways.net';
 export const DefaultUrlScheme = '/bzz-raw:/';
@@ -107,9 +107,9 @@ export const uploadData = async (data: string): Promise<string> => {
     return text;
 };
 
-export const downloadData = async (hash: string): Promise<string> => {
+export const downloadData = async (hash: string, timeout: number = 0): Promise<string> => {
     const url = DefaultGateway + '/bzz:/' + hash + '/';
-    const response = await safeFetch(url);
+    const response = await safeFetchWithTimeout(url, undefined, timeout);
     const text = await response.text();
     return text;
 };
@@ -159,10 +159,10 @@ export const downloadUserFeed = async (identity: PublicIdentity): Promise<string
     return await downloadFeed(`bzz-feed:/?user=${identity.address}`);
 };
 
-export const downloadFeed = async (feedUri: string): Promise<string> => {
+export const downloadFeed = async (feedUri: string, timeout: number = 0): Promise<string> => {
     const url = DefaultGateway + '/' + feedUri;
     Debug.log('downloadFeed: ', url);
-    const response = await safeFetch(url);
+    const response = await safeFetchWithTimeout(url, undefined, timeout);
     const text = await response.text();
     return text;
 };

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -4,7 +4,9 @@ const Url = require('url');
 export class Utils {
     public static async timeout<T>(ms, promise: Promise<T>): Promise<T> {
         return new Promise<T>((resolve, reject) => {
-            setTimeout(() => reject(new Error('timeout')), ms);
+            if (ms > 0) {
+                setTimeout(() => reject(new Error('timeout')), ms);
+            }
             promise.then(resolve, reject);
         });
     }

--- a/src/components/IdentitySettings.tsx
+++ b/src/components/IdentitySettings.tsx
@@ -11,6 +11,7 @@ import {
     Share,
     ShareContent,
     ShareOptions,
+    Platform,
 } from 'react-native';
 
 import { SimpleTextInput } from './SimpleTextInput';
@@ -51,10 +52,11 @@ const generateQRCodeValue = (feed?: Feed): string => {
 const showShareDialog = async (feed?: Feed) => {
     const url = feed != null ? feed.url : '';
     const title = 'Share your feed';
+    const message = Platform.OS === 'android' ? url : undefined;
     const content: ShareContent = {
         url,
         title,
-        message: url,
+        message,
     };
     const options: ShareOptions = {
     };


### PR DESCRIPTION
If content is missing (#66) updating a feed depends on the timeout of the gateway, which is usually around one minute.
This fix somewhat makes the UX better when content is missing, because after 10 seconds it will fail, but won't block showing other successfully downloaded feeds.