### PR TITLE
Download selected feeds

### DIFF
--- a/src/components/YourFeed.tsx
+++ b/src/components/YourFeed.tsx
@@ -40,7 +40,7 @@ import { Feed } from '../models/Feed';
 const WindowWidth = Dimensions.get('window').width;
 
 export interface DispatchProps {
-    onRefreshPosts: () => void;
+    onRefreshPosts: (feeds: Feed[]) => void;
     onDeletePost: (post: Post) => void;
     onSavePost: (post: Post) => void;
     onSharePost: (post: Post) => void;
@@ -204,7 +204,7 @@ export class YourFeed extends React.PureComponent<DispatchProps & StateProps, Yo
         this.setState({
             isRefreshing: true,
         });
-        this.props.onRefreshPosts();
+        this.props.onRefreshPosts(this.props.feeds);
     }
 
     private onFollowPressed = async (author: Author) => {

--- a/src/containers/EditFeedContainer.ts
+++ b/src/containers/EditFeedContainer.ts
@@ -15,11 +15,11 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
     return {
         onAddFeed: (feed: Feed) => {
             dispatch(Actions.addFeed(feed));
-            dispatch(AsyncActions.downloadPosts());
+            dispatch(AsyncActions.downloadPostsFromFeeds([feed]));
         },
         onRemoveFeed: (feed: Feed) => {
             dispatch(Actions.removeFeed(feed));
-            dispatch(AsyncActions.downloadPosts());
+            dispatch(AsyncActions.downloadFollowedFeedPosts());
         },
     };
 };

--- a/src/containers/FavoritesContainer.ts
+++ b/src/containers/FavoritesContainer.ts
@@ -21,7 +21,7 @@ const mapStateToProps = (state: AppState, ownProps): StateProps => {
     return {
         navigation: ownProps.navigation,
         posts: posts,
-        feeds: state.feeds.filter(feed => feed != null && feed.followed === true).toArray(),
+        feeds: favoriteFeeds,
         knownFeeds: state.feeds.filter(feed => feed != null && feed.followed !== true).toArray(),
         settings: state.settings,
         yourFeedVariant: 'favorite',
@@ -31,8 +31,8 @@ const mapStateToProps = (state: AppState, ownProps): StateProps => {
 
 const mapDispatchToProps = (dispatch): DispatchProps => {
     return {
-        onRefreshPosts: () => {
-            dispatch(AsyncActions.downloadPosts());
+        onRefreshPosts: (feeds: Feed[]) => {
+            dispatch(AsyncActions.downloadPostsFromFeeds(feeds));
         },
         onDeletePost: (post: Post) => {
             // do nothing

--- a/src/containers/FeedContainer.ts
+++ b/src/containers/FeedContainer.ts
@@ -6,14 +6,17 @@ import { Post } from '../models/Post';
 import { Feed } from '../models/Feed';
 
 const mapStateToProps = (state: AppState, ownProps): StateProps => {
+    const authorUri = ownProps.navigation.state.params.author.uri;
+    const selectedFeeds = state.feeds.filter(feed =>
+        feed != null && feed.followed === true && feed.feedUrl === authorUri).toArray();
     const posts = state.rssPosts.concat(state.localPosts)
-        .filter(post => post != null && post.author != null && post.author.uri === ownProps.navigation.state.params.author.uri)
+        .filter(post => post != null && post.author != null && post.author.uri === authorUri)
         .toArray();
 
     return {
         navigation: ownProps.navigation,
         posts: posts,
-        feeds: state.feeds.filter(feed => feed != null && feed.followed === true).toArray(),
+        feeds: selectedFeeds,
         knownFeeds: state.feeds.filter(feed => feed != null && feed.followed !== true).toArray(),
         settings: state.settings,
         yourFeedVariant: 'feed',
@@ -23,8 +26,8 @@ const mapStateToProps = (state: AppState, ownProps): StateProps => {
 
 const mapDispatchToProps = (dispatch): DispatchProps => {
     return {
-        onRefreshPosts: () => {
-            dispatch(AsyncActions.downloadPosts());
+        onRefreshPosts: (feeds: Feed[]) => {
+            dispatch(AsyncActions.downloadPostsFromFeeds(feeds));
         },
         onDeletePost: (post: Post) => {
             // do nothing

--- a/src/containers/NewsFeedContainer.ts
+++ b/src/containers/NewsFeedContainer.ts
@@ -25,7 +25,7 @@ const mapStateToProps = (state: AppState, ownProps): StateProps => {
     return {
         navigation: ownProps.navigation,
         posts: filteredPosts,
-        feeds: state.feeds.filter(feed => feed != null && feed.followed === true).toArray(),
+        feeds: followedFeeds,
         knownFeeds: state.feeds.filter(feed => feed != null && feed.followed !== true).toArray(),
         settings: state.settings,
         yourFeedVariant: 'news',
@@ -35,8 +35,8 @@ const mapStateToProps = (state: AppState, ownProps): StateProps => {
 
 const mapDispatchToProps = (dispatch): DispatchProps => {
     return {
-        onRefreshPosts: () => {
-            dispatch(AsyncActions.downloadPosts());
+        onRefreshPosts: (feeds: Feed[]) => {
+            dispatch(AsyncActions.downloadPostsFromFeeds(feeds));
         },
         onDeletePost: (post: Post) => {
             // do nothing

--- a/src/containers/WelcomeContainer.ts
+++ b/src/containers/WelcomeContainer.ts
@@ -23,7 +23,7 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
             dispatch(Actions.updateAuthorPicturePath(image));
         },
         onDownloadPosts: () => {
-            dispatch(AsyncActions.downloadPosts());
+            dispatch(AsyncActions.downloadFollowedFeedPosts());
         },
     };
 };

--- a/src/containers/YourFeedContainer.ts
+++ b/src/containers/YourFeedContainer.ts
@@ -22,7 +22,7 @@ const mapStateToProps = (state: AppState, ownProps): StateProps => {
 
 const mapDispatchToProps = (dispatch): DispatchProps => {
     return {
-        onRefreshPosts: () => {
+        onRefreshPosts: (feeds: Feed[]) => {
             // workaround to finish refresh
             dispatch(Actions.timeTick());
         },


### PR DESCRIPTION
There is a new async action `downloadPostsFromFeeds`, and with that it's possible to download selected feeds. It will update the posts in the `rssPosts` finding the changes by author.

It's a bit sketchy that we rely on the fact that the `author.uri` is the same as the `feed.feedUrl`, maybe that could be a topic of further improvements after this is finished:
https://github.com/agazso/postmodern/pull/99

