### PR TITLE
Refactor your feed 2

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -33,55 +33,51 @@ export interface DispatchProps {
 type CardProps = StateProps & DispatchProps;
 
 export const Card = (props: CardProps) => {
-    if (props.post.images.length === 0) {
-        return <CardWithText {...props}/>;
-    } else {
-        return (
-            <View
-                style={[styles.container, {
-                    margin: 0,
-                    padding: 0,
-                    paddingTop: 5,
-                    borderWidth: 0,
-                }]}
-                key={'card-' + props.post._id}
-                testID={'YourFeed/Post' + props.post._id}
-            >
+    return (
+        <View
+            style={[styles.container, {
+                margin: 0,
+                padding: 0,
+                paddingTop: 5,
+                borderWidth: 0,
+            }]}
+            key={'card-' + props.post._id}
+            testID={'YourFeed/Post' + props.post._id}
+        >
 
-                <CardTop post={props.post} navigate={props.navigate}/>
-                <TouchableOpacity
-                    activeOpacity={1}
-                    onLongPress={() => props.togglePostSelection(props.post)}
-                    onPress={() => openPost(props.post)}
-                    style = {{
-                        backgroundColor: '#fff',
-                        padding: 0,
-                        paddingTop: 0,
-                        marginTop: 0,
-                    }}
-                >
-                    {props.post.images.map((image, index) => {
-                        const [width, height] = calculateImageDimensions(image, WindowWidth, props.showSquareImages);
-                        return (
-                            <ImageView
-                                testID={image.uri || '' + index}
-                                key={image.uri || '' + index}
-                                source={image}
-                                style={{
-                                    width: width,
-                                    height: height,
-                                }}
-                            />
-                        );
-                    })}
-                    { props.post.text === '' ||
-                        <CardMarkdown key={props.post._id} text={props.post.text}/>
-                    }
-                    <ButtonList {...props}/>
-                </TouchableOpacity>
-            </View>
-        );
-    }
+            <CardTop post={props.post} navigate={props.navigate}/>
+            <TouchableOpacity
+                activeOpacity={1}
+                onLongPress={() => props.togglePostSelection(props.post)}
+                onPress={() => openPost(props.post)}
+                style = {{
+                    backgroundColor: '#fff',
+                    padding: 0,
+                    paddingTop: 0,
+                    marginTop: 0,
+                }}
+            >
+                {props.post.images.map((image, index) => {
+                    const [width, height] = calculateImageDimensions(image, WindowWidth, props.showSquareImages);
+                    return (
+                        <ImageView
+                            testID={image.uri || '' + index}
+                            key={image.uri || '' + index}
+                            source={image}
+                            style={{
+                                width: width,
+                                height: height,
+                            }}
+                        />
+                    );
+                })}
+                { props.post.text === '' ||
+                    <CardMarkdown key={props.post._id} text={props.post.text}/>
+                }
+                <ButtonList {...props}/>
+            </TouchableOpacity>
+        </View>
+    );
 };
 
 export const MemoizedCard = React.memo(Card);
@@ -154,31 +150,6 @@ const CardTop = (props: { post: Post, navigate: (view: string, {}) => void }) =>
                 <Text style={styles.location}>{printableTime}{hostnameText}</Text>
             </View>
         </TouchableOpacity>
-    );
-};
-
-export const CardWithText = (props: CardProps) => {
-    return (
-        <View
-            style={[styles.container, {
-                margin: 0,
-                paddingTop: 5,
-                borderWidth: 0,
-            }]}
-            key={'card-' + props.post._id}
-            testID={'YourFeed/Post' + props.post._id}
-        >
-            <TouchableOpacity
-                onLongPress={ () => props.togglePostSelection(props.post) }
-                onPress={ () => openPost(props.post)}
-                activeOpacity={1}
-            >
-                <CardTop post={props.post} navigate={props.navigate} />
-                { props.post.text != null &&
-                <CardMarkdown key={props.post._id} text={props.post.text}/>}
-            </TouchableOpacity>
-            <ButtonList {...props} />
-        </View>
     );
 };
 

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -32,7 +32,7 @@ export interface DispatchProps {
 
 type CardProps = StateProps & DispatchProps;
 
-export const Card = React.memo((props: CardProps) => {
+export const Card = (props: CardProps) => {
     if (props.post.images.length === 0) {
         return <CardWithText {...props}/>;
     } else {
@@ -82,7 +82,9 @@ export const Card = React.memo((props: CardProps) => {
             </View>
         );
     }
-});
+};
+
+export const MemoizedCard = React.memo(Card);
 
 const ActionIcon = (props: { name: string}) => {
     const iconSize = 20;

--- a/src/components/FavoritesFeedView.tsx
+++ b/src/components/FavoritesFeedView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { YourFeed } from './YourFeed';
+import { RefreshableFeed } from './RefreshableFeed';
 import { Feed } from '../models/Feed';
 import { Post } from '../models/Post';
 import { Settings } from '../models/Settings';
@@ -20,14 +20,14 @@ type Props = StateProps & DispatchProps;
 
 export const FavoritesFeedView = (props: Props) => {
     return (
-        <YourFeed {...props}>
+        <RefreshableFeed {...props}>
             {{
                 listHeader: <NavigationHeader
                                 leftButtonText=''
                                 title='Favorites'
                         />,
             }}
-        </YourFeed>
+        </RefreshableFeed>
     );
 };
 

--- a/src/components/FavoritesFeedView.tsx
+++ b/src/components/FavoritesFeedView.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { YourFeed } from './YourFeed';
+import { Feed } from '../models/Feed';
+import { Post } from '../models/Post';
+import { Settings } from '../models/Settings';
+import { NavigationHeader } from './NavigationHeader';
+
+export interface DispatchProps {
+    onRefreshPosts: (feeds: Feed[]) => void;
+}
+
+export interface StateProps {
+    navigation: any;
+    posts: Post[];
+    feeds: Feed[];
+    settings: Settings;
+}
+
+type Props = StateProps & DispatchProps;
+
+export const FavoritesFeedView = (props: Props) => {
+    return (
+        <YourFeed {...props}>
+            {{
+                listHeader: <NavigationHeader
+                                leftButtonText=''
+                                title='Favorites'
+                        />,
+            }}
+        </YourFeed>
+    );
+};
+
+export const MemoizedFavoritesFeedView = React.memo(FavoritesFeedView);

--- a/src/components/FavoritesFeedView.tsx
+++ b/src/components/FavoritesFeedView.tsx
@@ -30,5 +30,3 @@ export const FavoritesFeedView = (props: Props) => {
         </RefreshableFeed>
     );
 };
-
-export const MemoizedFavoritesFeedView = React.memo(FavoritesFeedView);

--- a/src/components/FeedHeader.tsx
+++ b/src/components/FeedHeader.tsx
@@ -23,7 +23,7 @@ export interface DispatchProps {
     onSavePost: (post: Post) => void;
 }
 
-type Props = StateProps & DispatchProps;
+export type Props = StateProps & DispatchProps;
 
 export class FeedHeader extends React.PureComponent<Props> {
     public openImagePicker = async () => {

--- a/src/components/FeedView.tsx
+++ b/src/components/FeedView.tsx
@@ -3,7 +3,6 @@ import { RefreshableFeed } from './RefreshableFeed';
 import { Feed } from '../models/Feed';
 import { Post, Author } from '../models/Post';
 import { Settings } from '../models/Settings';
-import { FeedHeader } from './FeedHeader';
 import { NavigationHeader } from './NavigationHeader';
 import { Colors } from '../styles';
 

--- a/src/components/FeedView.tsx
+++ b/src/components/FeedView.tsx
@@ -22,7 +22,6 @@ export interface StateProps {
     navigation: any;
     posts: Post[];
     feeds: Feed[];
-    knownFeeds: Feed[];
     settings: Settings;
     isOwnFeed: boolean;
 }
@@ -32,7 +31,7 @@ type Props = StateProps & DispatchProps;
 export const FeedView = (props: Props) => {
     const navParams = props.navigation.state.params;
     const isFollowedFeed = navParams != null &&
-                    props.feeds.find(feed => feed.feedUrl === navParams.author.uri) != null;
+                    props.feeds.find(feed => feed.feedUrl === navParams.author.uri && feed.followed === true) != null;
     return (
         <RefreshableFeed {...props}>
             {{
@@ -54,7 +53,6 @@ export const FeedView = (props: Props) => {
                                       onPressRightButton1={async () => {
                                           return !props.isOwnFeed && await onFollowPressed(navParams.author,
                                                                                            props.feeds,
-                                                                                           props.knownFeeds,
                                                                                            props.onUnfollowFeed,
                                                                                            props.onFollowFeed);
                                       }}
@@ -71,12 +69,12 @@ const isFavorite = (feeds: Feed[], uri: string): boolean => {
     return feed != null && !!feed.favorite;
 };
 
-const onFollowPressed = async (author: Author, feeds: Feed[], knownFeeds: Feed[], onUnfollowFeed: (feed: Feed) => void, onFollowFeed: (feed: Feed) => void) => {
-    const followedFeed = feeds.find(feed => feed.feedUrl === author.uri);
+const onFollowPressed = async (author: Author, feeds: Feed[], onUnfollowFeed: (feed: Feed) => void, onFollowFeed: (feed: Feed) => void) => {
+    const followedFeed = feeds.find(feed => feed.feedUrl === author.uri && feed.followed === true);
     if (followedFeed != null) {
         await unfollowFeed(followedFeed, onUnfollowFeed);
     } else {
-        followFeed(author, knownFeeds, onFollowFeed);
+        followFeed(author, feeds, onFollowFeed);
     }
 };
 
@@ -87,8 +85,8 @@ const unfollowFeed = async (feed: Feed, onUnfollowFeed: (feed: Feed) => void) =>
     }
 };
 
-const followFeed = (author: Author, knownFeeds: Feed[], onFollowFeed: (feed: Feed) => void) => {
-    const knownFeed = knownFeeds.find(feed => feed.feedUrl === author.uri);
+const followFeed = (author: Author, feeds: Feed[], onFollowFeed: (feed: Feed) => void) => {
+    const knownFeed = feeds.find(feed => feed.feedUrl === author.uri && feed.followed !== true);
     if (knownFeed != null) {
         onFollowFeed(knownFeed);
     }

--- a/src/components/FeedView.tsx
+++ b/src/components/FeedView.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { YourFeed } from './YourFeed';
+import { Feed } from '../models/Feed';
+import { Post, Author } from '../models/Post';
+import { Settings } from '../models/Settings';
+import { FeedHeader } from './FeedHeader';
+import { NavigationHeader } from './NavigationHeader';
+import { Colors } from '../styles';
+
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
+import * as AreYouSureDialog from './AreYouSureDialog';
+
+export interface DispatchProps {
+    onRefreshPosts: (feeds: Feed[]) => void;
+    onFollowFeed: (feed: Feed) => void;
+    onUnfollowFeed: (feed: Feed) => void;
+    onToggleFavorite: (feedUrl: string) => void;
+}
+
+export interface StateProps {
+    navigation: any;
+    posts: Post[];
+    feeds: Feed[];
+    knownFeeds: Feed[];
+    settings: Settings;
+    isOwnFeed: boolean;
+}
+
+type Props = StateProps & DispatchProps;
+
+export const FeedView = (props: Props) => {
+    const navParams = props.navigation.state.params;
+    const isFollowedFeed = navParams != null &&
+                    props.feeds.find(feed => feed.feedUrl === navParams.author.uri) != null;
+    return (
+        <YourFeed {...props}>
+            {{
+                navigationHeader: <NavigationHeader
+                                      onPressLeftButton={() => props.navigation.goBack(null)}
+                                      rightButtonText1={!props.isOwnFeed ? <Icon
+                                          name={isFollowedFeed ? 'link-variant-off' : 'link-variant'}
+                                          size={20}
+                                          color={Colors.DARK_GRAY}
+                                      /> : undefined}
+                                      rightButtonText2={!props.isOwnFeed ? <MaterialIcon
+                                          name={'favorite'}
+                                          size={20}
+                                          color={isFollowedFeed
+                                              ? isFavorite(props.feeds, navParams.author.uri) ? Colors.BRAND_RED : Colors.DARK_GRAY
+                                              : 'transparent'
+                                          }
+                                      /> : undefined}
+                                      onPressRightButton1={async () => {
+                                          return !props.isOwnFeed && await onFollowPressed(navParams.author,
+                                                                                           props.feeds,
+                                                                                           props.knownFeeds,
+                                                                                           props.onUnfollowFeed,
+                                                                                           props.onFollowFeed);
+                                      }}
+                                      onPressRightButton2={() => !props.isOwnFeed && isFollowedFeed && props.onToggleFavorite(navParams.author.uri)}
+                                      title={navParams ? navParams.author.name : 'Favorites'}
+                                  />,
+            }}
+        </YourFeed>
+    );
+};
+
+const isFavorite = (feeds: Feed[], uri: string): boolean => {
+    const feed = feeds.find(value => value.feedUrl === uri);
+    return feed != null && !!feed.favorite;
+};
+
+const onFollowPressed = async (author: Author, feeds: Feed[], knownFeeds: Feed[], onUnfollowFeed: (feed: Feed) => void, onFollowFeed: (feed: Feed) => void) => {
+    const followedFeed = feeds.find(feed => feed.feedUrl === author.uri);
+    if (followedFeed != null) {
+        await unfollowFeed(followedFeed, onUnfollowFeed);
+    } else {
+        followFeed(author, knownFeeds, onFollowFeed);
+    }
+};
+
+const unfollowFeed = async (feed: Feed, onUnfollowFeed: (feed: Feed) => void) => {
+    const confirmUnfollow = await AreYouSureDialog.show('Are you sure you want to unfollow?');
+    if (confirmUnfollow) {
+        onUnfollowFeed(feed);
+    }
+};
+
+const followFeed = (author: Author, knownFeeds: Feed[], onFollowFeed: (feed: Feed) => void) => {
+    const knownFeed = knownFeeds.find(feed => feed.feedUrl === author.uri);
+    if (knownFeed != null) {
+        onFollowFeed(knownFeed);
+    }
+};
+
+export const MemoizedFeedView = React.memo(FeedView);

--- a/src/components/FeedView.tsx
+++ b/src/components/FeedView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { YourFeed } from './YourFeed';
+import { RefreshableFeed } from './RefreshableFeed';
 import { Feed } from '../models/Feed';
 import { Post, Author } from '../models/Post';
 import { Settings } from '../models/Settings';
@@ -34,7 +34,7 @@ export const FeedView = (props: Props) => {
     const isFollowedFeed = navParams != null &&
                     props.feeds.find(feed => feed.feedUrl === navParams.author.uri) != null;
     return (
-        <YourFeed {...props}>
+        <RefreshableFeed {...props}>
             {{
                 navigationHeader: <NavigationHeader
                                       onPressLeftButton={() => props.navigation.goBack(null)}
@@ -62,7 +62,7 @@ export const FeedView = (props: Props) => {
                                       title={navParams ? navParams.author.name : 'Favorites'}
                                   />,
             }}
-        </YourFeed>
+        </RefreshableFeed>
     );
 };
 

--- a/src/components/FeedView.tsx
+++ b/src/components/FeedView.tsx
@@ -90,5 +90,3 @@ const followFeed = (author: Author, feeds: Feed[], onFollowFeed: (feed: Feed) =>
         onFollowFeed(knownFeed);
     }
 };
-
-export const MemoizedFeedView = React.memo(FeedView);

--- a/src/components/NewsFeedView.tsx
+++ b/src/components/NewsFeedView.tsx
@@ -30,5 +30,3 @@ export const NewsFeedView = (props: Props) => {
         </RefreshableFeed>
     );
 };
-
-export const MemoizedNewsFeedView = React.memo(NewsFeedView);

--- a/src/components/NewsFeedView.tsx
+++ b/src/components/NewsFeedView.tsx
@@ -13,7 +13,6 @@ export interface StateProps {
     navigation: any;
     posts: Post[];
     feeds: Feed[];
-    knownFeeds: Feed[];
     settings: Settings;
 }
 

--- a/src/components/NewsFeedView.tsx
+++ b/src/components/NewsFeedView.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { YourFeed } from './YourFeed';
+import { Feed } from '../models/Feed';
+import { Post } from '../models/Post';
+import { Settings } from '../models/Settings';
+import { NavigationHeader } from './NavigationHeader';
+
+export interface DispatchProps {
+    onRefreshPosts: (feeds: Feed[]) => void;
+}
+
+export interface StateProps {
+    navigation: any;
+    posts: Post[];
+    feeds: Feed[];
+    knownFeeds: Feed[];
+    settings: Settings;
+}
+
+type Props = StateProps & DispatchProps;
+
+export const NewsFeedView = (props: Props) => {
+    return (
+        <YourFeed {...props}>
+            {{
+                listHeader: <NavigationHeader
+                            leftButtonText=''
+                            title='News'
+                        />,
+            }}
+        </YourFeed>
+    );
+};
+
+export const MemoizedNewsFeedView = React.memo(NewsFeedView);

--- a/src/components/NewsFeedView.tsx
+++ b/src/components/NewsFeedView.tsx
@@ -23,9 +23,9 @@ export const NewsFeedView = (props: Props) => {
         <RefreshableFeed {...props}>
             {{
                 listHeader: <NavigationHeader
-                            leftButtonText=''
-                            title='News'
-                        />,
+                                leftButtonText=''
+                                title='News'
+                            />,
             }}
         </RefreshableFeed>
     );

--- a/src/components/NewsFeedView.tsx
+++ b/src/components/NewsFeedView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { YourFeed } from './YourFeed';
+import { RefreshableFeed } from './RefreshableFeed';
 import { Feed } from '../models/Feed';
 import { Post } from '../models/Post';
 import { Settings } from '../models/Settings';
@@ -21,14 +21,14 @@ type Props = StateProps & DispatchProps;
 
 export const NewsFeedView = (props: Props) => {
     return (
-        <YourFeed {...props}>
+        <RefreshableFeed {...props}>
             {{
                 listHeader: <NavigationHeader
                             leftButtonText=''
                             title='News'
                         />,
             }}
-        </YourFeed>
+        </RefreshableFeed>
     );
 };
 

--- a/src/components/RefreshableFeed.tsx
+++ b/src/components/RefreshableFeed.tsx
@@ -13,6 +13,8 @@ import { StatusBarView } from './StatusBarView';
 import { Settings } from '../models/Settings';
 import { Feed } from '../models/Feed';
 import { CardContainer } from '../containers/CardContainer';
+import { Props as NavHeaderProps } from './NavigationHeader';
+import { Props as FeedHeaderProps } from './FeedHeader';
 
 export interface DispatchProps {
     onRefreshPosts: (feeds: Feed[]) => void;
@@ -24,9 +26,9 @@ export interface StateProps {
     feeds: Feed[];
     settings: Settings;
     children: {
-        // using here other then any would be good, but it does not typecheck
-        listHeader?: React.ReactElement<any>,
-        navigationHeader?: React.ReactElement<any>,
+        // WARNING, type parameter included for reference, but it does not typecheck
+        listHeader?: React.ReactElement<FeedHeaderProps>,
+        navigationHeader?: React.ReactElement<NavHeaderProps>,
     };
 }
 

--- a/src/components/RefreshableFeed.tsx
+++ b/src/components/RefreshableFeed.tsx
@@ -24,19 +24,19 @@ export interface StateProps {
     feeds: Feed[];
     settings: Settings;
     children: {
-        // using here other then any would be good, but it gives a false sense of security, it does not typecheck
+        // using here other then any would be good, but it does not typecheck
         listHeader?: React.ReactElement<any>,
         navigationHeader?: React.ReactElement<any>,
     };
 }
 
-interface YourFeedState {
+interface RefreshableFeedState {
     selectedPost: Post | null;
     isRefreshing: boolean;
 }
 
-export class YourFeed extends React.PureComponent<DispatchProps & StateProps, YourFeedState> {
-    public state: YourFeedState = {
+export class RefreshableFeed extends React.PureComponent<DispatchProps & StateProps, RefreshableFeedState> {
+    public state: RefreshableFeedState = {
         selectedPost: null,
         isRefreshing: false,
     };

--- a/src/components/YourFeedView.tsx
+++ b/src/components/YourFeedView.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { YourFeed } from './YourFeed';
+import { Feed } from '../models/Feed';
+import { Post } from '../models/Post';
+import { Settings } from '../models/Settings';
+import { FeedHeader } from './FeedHeader';
+
+export interface DispatchProps {
+    onRefreshPosts: (feeds: Feed[]) => void;
+    onSavePost: (post: Post) => void;
+}
+
+export interface StateProps {
+    navigation: any;
+    posts: Post[];
+    feeds: Feed[];
+    settings: Settings;
+}
+
+type Props = StateProps & DispatchProps;
+
+export const YourFeedView = (props: Props) => {
+    return (
+        <YourFeed {...props}>
+            {{
+                listHeader: <FeedHeader
+                                navigation={props.navigation}
+                                onSavePost={props.onSavePost}
+                        />,
+            }}
+        </YourFeed>
+    );
+};
+
+export const MemoizedYourFeedView = React.memo(YourFeedView);

--- a/src/components/YourFeedView.tsx
+++ b/src/components/YourFeedView.tsx
@@ -31,5 +31,3 @@ export const YourFeedView = (props: Props) => {
         </RefreshableFeed>
     );
 };
-
-export const MemoizedYourFeedView = React.memo(YourFeedView);

--- a/src/components/YourFeedView.tsx
+++ b/src/components/YourFeedView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { YourFeed } from './YourFeed';
+import { RefreshableFeed } from './RefreshableFeed';
 import { Feed } from '../models/Feed';
 import { Post } from '../models/Post';
 import { Settings } from '../models/Settings';
@@ -21,14 +21,14 @@ type Props = StateProps & DispatchProps;
 
 export const YourFeedView = (props: Props) => {
     return (
-        <YourFeed {...props}>
+        <RefreshableFeed {...props}>
             {{
                 listHeader: <FeedHeader
                                 navigation={props.navigation}
                                 onSavePost={props.onSavePost}
                         />,
             }}
-        </YourFeed>
+        </RefreshableFeed>
     );
 };
 

--- a/src/components/YourFeedView.tsx
+++ b/src/components/YourFeedView.tsx
@@ -26,7 +26,7 @@ export const YourFeedView = (props: Props) => {
                 listHeader: <FeedHeader
                                 navigation={props.navigation}
                                 onSavePost={props.onSavePost}
-                        />,
+                            />,
             }}
         </RefreshableFeed>
     );

--- a/src/containers/CardContainer.ts
+++ b/src/containers/CardContainer.ts
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { AppState } from '../reducers/index';
-import { StateProps, DispatchProps, Card } from '../components/Card';
+import { StateProps, DispatchProps, MemoizedCard } from '../components/Card';
 import { Post } from '../models/Post';
 import { AsyncActions } from '../actions/Actions';
 
@@ -38,4 +38,4 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
 export const CardContainer = connect<StateProps, DispatchProps, {}>(
     mapStateToProps,
     mapDispatchToProps
-)(Card);
+)(MemoizedCard);

--- a/src/containers/FavoritesContainer.ts
+++ b/src/containers/FavoritesContainer.ts
@@ -1,9 +1,10 @@
 import { connect } from 'react-redux';
 import { AppState } from '../reducers';
-import { StateProps, DispatchProps, YourFeed } from '../components/YourFeed';
-import { AsyncActions, Actions } from '../actions/Actions';
+import { StateProps, DispatchProps } from '../components/FavoritesFeedView';
+import { AsyncActions } from '../actions/Actions';
 import { Post } from '../models/Post';
 import { Feed } from '../models/Feed';
+import { MemoizedFavoritesFeedView } from '../components/FavoritesFeedView';
 
 const isPostFromFavoriteFeed = (post: Post, favoriteFeeds: Feed[]): boolean => {
     return favoriteFeeds.find(feed => {
@@ -22,10 +23,7 @@ const mapStateToProps = (state: AppState, ownProps): StateProps => {
         navigation: ownProps.navigation,
         posts: posts,
         feeds: favoriteFeeds,
-        knownFeeds: state.feeds.filter(feed => feed != null && feed.followed !== true).toArray(),
         settings: state.settings,
-        yourFeedVariant: 'favorite',
-        isOwnFeed: false,
     };
 };
 
@@ -34,22 +32,10 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
         onRefreshPosts: (feeds: Feed[]) => {
             dispatch(AsyncActions.downloadPostsFromFeeds(feeds));
         },
-        onSavePost: (post: Post) => {
-            // do nothing
-        },
-        onUnfollowFeed: (feed: Feed) => {
-            // do nothing
-        },
-        onFollowFeed: (feed: Feed) => {
-            // do nothing
-        },
-        onToggleFavorite: (feedUrl: string) => {
-            dispatch(Actions.toggleFeedFavorite(feedUrl));
-        },
     };
 };
 
 export const FavoritesContainer = connect<StateProps, DispatchProps, {}>(
     mapStateToProps,
     mapDispatchToProps,
-)(YourFeed);
+)(MemoizedFavoritesFeedView);

--- a/src/containers/FavoritesContainer.ts
+++ b/src/containers/FavoritesContainer.ts
@@ -4,7 +4,7 @@ import { StateProps, DispatchProps } from '../components/FavoritesFeedView';
 import { AsyncActions } from '../actions/Actions';
 import { Post } from '../models/Post';
 import { Feed } from '../models/Feed';
-import { MemoizedFavoritesFeedView } from '../components/FavoritesFeedView';
+import { FavoritesFeedView } from '../components/FavoritesFeedView';
 
 const isPostFromFavoriteFeed = (post: Post, favoriteFeeds: Feed[]): boolean => {
     return favoriteFeeds.find(feed => {
@@ -38,4 +38,4 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
 export const FavoritesContainer = connect<StateProps, DispatchProps, {}>(
     mapStateToProps,
     mapDispatchToProps,
-)(MemoizedFavoritesFeedView);
+)(FavoritesFeedView);

--- a/src/containers/FeedContainer.ts
+++ b/src/containers/FeedContainer.ts
@@ -6,8 +6,7 @@ import { Feed } from '../models/Feed';
 
 const mapStateToProps = (state: AppState, ownProps): StateProps => {
     const authorUri = ownProps.navigation.state.params.author.uri;
-    const selectedFeeds = state.feeds.filter(feed =>
-        feed != null && feed.followed === true && feed.feedUrl === authorUri).toArray();
+    const selectedFeeds = state.feeds.filter(feed => feed != null && feed.feedUrl === authorUri).toArray();
     const posts = state.rssPosts.concat(state.localPosts)
         .filter(post => post != null && post.author != null && post.author.uri === authorUri)
         .toArray();
@@ -16,7 +15,6 @@ const mapStateToProps = (state: AppState, ownProps): StateProps => {
         navigation: ownProps.navigation,
         posts: posts,
         feeds: selectedFeeds,
-        knownFeeds: state.feeds.filter(feed => feed != null && feed.followed !== true).toArray(),
         settings: state.settings,
         isOwnFeed: state.author.uri === ownProps.navigation.state.params.author.uri,
     };

--- a/src/containers/FeedContainer.ts
+++ b/src/containers/FeedContainer.ts
@@ -1,8 +1,7 @@
 import { connect } from 'react-redux';
 import { AppState } from '../reducers';
-import { StateProps, DispatchProps, YourFeed } from '../components/YourFeed';
+import { StateProps, DispatchProps, MemoizedFeedView } from '../components/FeedView';
 import { AsyncActions, Actions } from '../actions/Actions';
-import { Post } from '../models/Post';
 import { Feed } from '../models/Feed';
 
 const mapStateToProps = (state: AppState, ownProps): StateProps => {
@@ -19,7 +18,6 @@ const mapStateToProps = (state: AppState, ownProps): StateProps => {
         feeds: selectedFeeds,
         knownFeeds: state.feeds.filter(feed => feed != null && feed.followed !== true).toArray(),
         settings: state.settings,
-        yourFeedVariant: 'feed',
         isOwnFeed: state.author.uri === ownProps.navigation.state.params.author.uri,
     };
 };
@@ -28,9 +26,6 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
     return {
         onRefreshPosts: (feeds: Feed[]) => {
             dispatch(AsyncActions.downloadPostsFromFeeds(feeds));
-        },
-        onSavePost: (post: Post) => {
-            // do nothing
         },
         onUnfollowFeed: (feed: Feed) => {
             dispatch(Actions.unfollowFeed(feed));
@@ -47,4 +42,4 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
 export const FeedContainer = connect<StateProps, DispatchProps, {}>(
     mapStateToProps,
     mapDispatchToProps,
-)(YourFeed);
+)(MemoizedFeedView);

--- a/src/containers/FeedContainer.ts
+++ b/src/containers/FeedContainer.ts
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { AppState } from '../reducers';
-import { StateProps, DispatchProps, MemoizedFeedView } from '../components/FeedView';
+import { StateProps, DispatchProps, FeedView } from '../components/FeedView';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { Feed } from '../models/Feed';
 
@@ -40,4 +40,4 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
 export const FeedContainer = connect<StateProps, DispatchProps, {}>(
     mapStateToProps,
     mapDispatchToProps,
-)(MemoizedFeedView);
+)(FeedView);

--- a/src/containers/NewsFeedContainer.ts
+++ b/src/containers/NewsFeedContainer.ts
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
 import { AppState } from '../reducers';
-import { StateProps, DispatchProps, YourFeed } from '../components/YourFeed';
 import { RSSPostManager } from '../RSSPostManager';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { Post } from '../models/Post';
 import { Feed } from '../models/Feed';
+import { StateProps, DispatchProps, MemoizedNewsFeedView } from '../components/NewsFeedView';
 
 const isPostFromFollowedFeed = (post: Post, followedFeeds: Feed[]): boolean => {
     return followedFeeds.find(feed => {
@@ -28,8 +28,6 @@ const mapStateToProps = (state: AppState, ownProps): StateProps => {
         feeds: followedFeeds,
         knownFeeds: state.feeds.filter(feed => feed != null && feed.followed !== true).toArray(),
         settings: state.settings,
-        yourFeedVariant: 'news',
-        isOwnFeed: false,
     };
 };
 
@@ -38,22 +36,10 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
         onRefreshPosts: (feeds: Feed[]) => {
             dispatch(AsyncActions.downloadPostsFromFeeds(feeds));
         },
-        onSavePost: (post: Post) => {
-            // do nothing
-        },
-        onUnfollowFeed: (feed: Feed) => {
-            // do nothing
-        },
-        onFollowFeed: (feed: Feed) => {
-            // do nothing
-        },
-        onToggleFavorite: (feedUrl: string) => {
-            dispatch(Actions.toggleFeedFavorite(feedUrl));
-        },
     };
 };
 
 export const NewsFeedContainer = connect<StateProps, DispatchProps, {}>(
     mapStateToProps,
     mapDispatchToProps,
-)(YourFeed);
+)(MemoizedNewsFeedView);

--- a/src/containers/NewsFeedContainer.ts
+++ b/src/containers/NewsFeedContainer.ts
@@ -26,7 +26,6 @@ const mapStateToProps = (state: AppState, ownProps): StateProps => {
         navigation: ownProps.navigation,
         posts: filteredPosts,
         feeds: followedFeeds,
-        knownFeeds: state.feeds.filter(feed => feed != null && feed.followed !== true).toArray(),
         settings: state.settings,
     };
 };

--- a/src/containers/NewsFeedContainer.ts
+++ b/src/containers/NewsFeedContainer.ts
@@ -4,7 +4,7 @@ import { RSSPostManager } from '../RSSPostManager';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { Post } from '../models/Post';
 import { Feed } from '../models/Feed';
-import { StateProps, DispatchProps, MemoizedNewsFeedView } from '../components/NewsFeedView';
+import { StateProps, DispatchProps, NewsFeedView } from '../components/NewsFeedView';
 
 const isPostFromFollowedFeed = (post: Post, followedFeeds: Feed[]): boolean => {
     return followedFeeds.find(feed => {
@@ -41,4 +41,4 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
 export const NewsFeedContainer = connect<StateProps, DispatchProps, {}>(
     mapStateToProps,
     mapDispatchToProps,
-)(MemoizedNewsFeedView);
+)(NewsFeedView);

--- a/src/containers/YourFeedContainer.ts
+++ b/src/containers/YourFeedContainer.ts
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { AppState } from '../reducers';
-import { StateProps, DispatchProps, YourFeed } from '../components/YourFeed';
+import { StateProps, DispatchProps, MemoizedYourFeedView } from '../components/YourFeedView';
 import { Post } from '../models/Post';
 import { Actions, AsyncActions } from '../actions/Actions';
 import { Feed } from '../models/Feed';
@@ -13,10 +13,7 @@ const mapStateToProps = (state: AppState, ownProps): StateProps => {
         navigation: ownProps.navigation,
         posts: filteredPosts,
         feeds: state.feeds.filter(feed => feed != null && feed.followed === true).toArray(),
-        knownFeeds: state.feeds.filter(feed => feed != null && feed.followed !== true).toArray(),
         settings: state.settings,
-        yourFeedVariant: 'your',
-        isOwnFeed: false,
     };
 };
 
@@ -29,19 +26,10 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
         onSavePost: (post: Post) => {
             dispatch(AsyncActions.createPost(post));
         },
-        onUnfollowFeed: (feed: Feed) => {
-            // do nothing
-        },
-        onFollowFeed: (feed: Feed) => {
-            // do nothing
-        },
-        onToggleFavorite: (feedUrl: string) => {
-            // do nothing
-        },
     };
 };
 
 export const YourFeedContainer = connect<StateProps, DispatchProps, {}>(
     mapStateToProps,
     mapDispatchToProps,
-)(YourFeed);
+)(MemoizedYourFeedView);

--- a/src/containers/YourFeedContainer.ts
+++ b/src/containers/YourFeedContainer.ts
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { AppState } from '../reducers';
-import { StateProps, DispatchProps, MemoizedYourFeedView } from '../components/YourFeedView';
+import { StateProps, DispatchProps, YourFeedView } from '../components/YourFeedView';
 import { Post } from '../models/Post';
 import { Actions, AsyncActions } from '../actions/Actions';
 import { Feed } from '../models/Feed';
@@ -32,4 +32,4 @@ const mapDispatchToProps = (dispatch): DispatchProps => {
 export const YourFeedContainer = connect<StateProps, DispatchProps, {}>(
     mapStateToProps,
     mapDispatchToProps,
-)(MemoizedYourFeedView);
+)(YourFeedView);

--- a/test/components/CardTest.tsx
+++ b/test/components/CardTest.tsx
@@ -34,7 +34,7 @@ describe('card test', () => {
         author: testAuthor,
     };
 
-    it.skip('should render without images CardWithText', () => {
+    it('should render without images CardWithText', () => {
         const renderer = ShallowRenderer.createRenderer();
         renderer.render(
             <Card

--- a/test/components/CardTest.tsx
+++ b/test/components/CardTest.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ShallowRenderer from 'react-test-renderer/shallow';
-import { Card, CardWithText } from '../../src/components/Card';
+import { Card } from '../../src/components/Card';
 import { Author, Post } from '../../src/models/Post';
 import TestRenderer from 'react-test-renderer';
 
@@ -33,24 +33,6 @@ describe('card test', () => {
     Let's see if we can assert something useful.`,
         author: testAuthor,
     };
-
-    it('should render without images CardWithText', () => {
-        const renderer = ShallowRenderer.createRenderer();
-        renderer.render(
-            <Card
-                post={testPostWithoutImage}
-                isSelected={false}
-                navigate={(_) => {}}
-                onDeletePost={(_) => {}}
-                onSharePost={(_) => {}}
-                togglePostSelection={(_) => {}}
-                showSquareImages={true}
-            />
-        );
-
-        const result = renderer.getRenderOutput();
-        expect(result.type).toBe(CardWithText);
-    });
 
     it('should render unselected post without images with the following components: Post, CardTop, without CardButtonList', () => {
         const result = TestRenderer.create(


### PR DESCRIPTION
fixes #89 by using children prop to inject view dependent UI. This simplifies the code a lot, also the empty functions code smell from the containers are gone. The only logic now in the old YourFeed - RefreshableFeed atm, is the refresh, and the post selection. Another dependency is the Card, if it doesn't cause issues in testing I would leave it as it is, we can always move it out later if we want to have a feed of other then Posts.