### PR TITLE
Fix refresh with reselect

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "redux": "=4.0.1",
     "redux-persist": "=5.10.0",
     "redux-thunk": "=2.3.0",
+    "reselect": "^4.0.0",
     "stream-browserify": "=2.0.1",
     "string_decoder": "=1.1.1",
     "ts-jest": "=23.10.4",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "redux": "=4.0.1",
     "redux-persist": "=5.10.0",
     "redux-thunk": "=2.3.0",
-    "reselect": "^4.0.0",
+    "reselect": "=4.0.0",
     "stream-browserify": "=2.0.1",
     "string_decoder": "=1.1.1",
     "ts-jest": "=23.10.4",

--- a/src/containers/FavoritesContainer.ts
+++ b/src/containers/FavoritesContainer.ts
@@ -2,21 +2,13 @@ import { connect } from 'react-redux';
 import { AppState } from '../reducers';
 import { StateProps, DispatchProps } from '../components/FavoritesFeedView';
 import { AsyncActions } from '../actions/Actions';
-import { Post } from '../models/Post';
 import { Feed } from '../models/Feed';
 import { FavoritesFeedView } from '../components/FavoritesFeedView';
-
-const isPostFromFavoriteFeed = (post: Post, favoriteFeeds: Feed[]): boolean => {
-    return favoriteFeeds.find(feed => {
-        return feed != null && post.author != null &&
-            feed.feedUrl === post.author.uri;
-    }) != null;
-};
+import { getFavoriteFeedsPosts, getFavoriteFeeds } from '../selectors/selectors';
 
 const mapStateToProps = (state: AppState, ownProps): StateProps => {
-    const favoriteFeeds = state.feeds.filter(feed => feed != null && feed.favorite === true);
-    const posts = state.rssPosts
-        .filter(post => post != null && isPostFromFavoriteFeed(post, favoriteFeeds));
+    const posts = getFavoriteFeedsPosts(state);
+    const favoriteFeeds = getFavoriteFeeds(state);
 
     return {
         navigation: ownProps.navigation,

--- a/src/containers/FeedContainer.ts
+++ b/src/containers/FeedContainer.ts
@@ -3,12 +3,14 @@ import { AppState } from '../reducers';
 import { StateProps, DispatchProps, FeedView } from '../components/FeedView';
 import { AsyncActions, Actions } from '../actions/Actions';
 import { Feed } from '../models/Feed';
+import { getFeedPosts } from '../selectors/selectors';
 
 export const mapStateToProps = (state: AppState, ownProps): StateProps => {
     const feedUrl = ownProps.navigation.state.params.feedUrl;
     const selectedFeeds = state.feeds.filter(feed => feed != null && feed.feedUrl === feedUrl);
-    const posts = state.rssPosts.concat(state.localPosts)
-        .filter(post => post != null && post.author != null && post.author.uri === feedUrl);
+    // Note: this is a moderately useful selector (recalculated if another feedUrl is opened (cache size == 1))
+    // see https://github.com/reduxjs/reselect/blob/master/README.md#accessing-react-props-in-selectors
+    const posts = getFeedPosts(state, feedUrl);
 
     return {
         onBack: () => ownProps.navigation.goBack(null),

--- a/src/containers/NewsFeedContainer.ts
+++ b/src/containers/NewsFeedContainer.ts
@@ -1,23 +1,14 @@
 import { connect } from 'react-redux';
 import { AppState } from '../reducers';
 import { RSSPostManager } from '../RSSPostManager';
-import { AsyncActions, Actions } from '../actions/Actions';
-import { Post } from '../models/Post';
+import { AsyncActions } from '../actions/Actions';
 import { Feed } from '../models/Feed';
 import { StateProps, DispatchProps, NewsFeedView } from '../components/NewsFeedView';
-
-const isPostFromFollowedFeed = (post: Post, followedFeeds: Feed[]): boolean => {
-    return followedFeeds.find(feed => {
-        return feed != null && post.author != null &&
-            feed.feedUrl === post.author.uri;
-    }) != null;
-};
+import { getFollowedNewsPosts, getFollowedFeeds } from '../selectors/selectors';
 
 const mapStateToProps = (state: AppState, ownProps): StateProps => {
-    const followedFeeds = state.feeds.filter(feed => feed != null && feed.followed === true);
-    const posts = state.rssPosts
-        .filter(post => post != null && isPostFromFollowedFeed(post, followedFeeds));
-    const filteredPosts = posts;
+    const followedFeeds = getFollowedFeeds(state);
+    const filteredPosts = getFollowedNewsPosts(state);
 
     RSSPostManager.setContentFilters(state.contentFilters);
 

--- a/src/selectors/selectors.ts
+++ b/src/selectors/selectors.ts
@@ -1,0 +1,38 @@
+import { createSelector } from 'reselect';
+import { AppState } from '../reducers';
+import { Post } from '../models/Post';
+import { Feed } from '../models/Feed';
+
+const isPostFromFollowedFeed = (post: Post, followedFeeds: Feed[]): boolean => {
+    return followedFeeds.find(feed => {
+        return feed != null && post.author != null &&
+            feed.feedUrl === post.author.uri;
+    }) != null;
+};
+
+const isPostFromFavoriteFeed = (post: Post, favoriteFeeds: Feed[]): boolean => {
+    return favoriteFeeds.find(feed => {
+        return feed != null && post.author != null &&
+            feed.feedUrl === post.author.uri;
+    }) != null;
+};
+
+const getFeeds = (state: AppState) => state.feeds;
+const getRssPosts = (state: AppState) => state.rssPosts;
+
+export const getFollowedFeeds = createSelector([ getFeeds ], (feeds) => {
+    return feeds.filter(feed => feed.followed === true);
+});
+
+export const getFavoriteFeeds = createSelector([ getFeeds ], (feeds) => {
+    return feeds.filter(feed => feed.favorite === true);
+});
+
+export const getFollowedNewsPosts = createSelector([ getRssPosts, getFollowedFeeds ], (rssPosts, followedFeeds) => {
+    return rssPosts.filter(post => isPostFromFollowedFeed(post, followedFeeds));
+});
+
+export const getFavoriteFeedsPosts = createSelector([ getRssPosts, getFavoriteFeeds ], (rssPosts, favoriteFeeds) => {
+    return rssPosts.filter(post => post != null && isPostFromFavoriteFeed(post, favoriteFeeds));
+
+});

--- a/src/selectors/selectors.ts
+++ b/src/selectors/selectors.ts
@@ -20,6 +20,12 @@ const isPostFromFavoriteFeed = (post: Post, favoriteFeeds: Feed[]): boolean => {
 const getFeeds = (state: AppState) => state.feeds;
 const getRssPosts = (state: AppState) => state.rssPosts;
 
+const getSelectedFeedPosts = (state: AppState, feedUrl: string) => {
+    return state.rssPosts
+        .concat(state.localPosts)
+        .filter(post => post != null && post.author != null && post.author.uri === feedUrl);
+};
+
 export const getFollowedFeeds = createSelector([ getFeeds ], (feeds) => {
     return feeds.filter(feed => feed.followed === true);
 });
@@ -35,4 +41,8 @@ export const getFollowedNewsPosts = createSelector([ getRssPosts, getFollowedFee
 export const getFavoriteFeedsPosts = createSelector([ getRssPosts, getFavoriteFeeds ], (rssPosts, favoriteFeeds) => {
     return rssPosts.filter(post => post != null && isPostFromFavoriteFeed(post, favoriteFeeds));
 
+});
+
+export const getFeedPosts = createSelector([ getSelectedFeedPosts ], (posts) => {
+    return posts;
 });


### PR DESCRIPTION
The goal of this PR is to fix a bug when the refresh indicator disappears due to unrelated state changes. This is solved by using the reselect package to add memoization for filterings done in the view containers.