### PR TITLE
Cli scripting

### DIFF
--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+source="src/cli.ts"
+target="build/dist/src/cli.js"
+
+npm run --silent tsc
+node "$target" $*

--- a/scripts/git_tag_release.sh
+++ b/scripts/git_tag_release.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+version="$1"
+
+git_commit_id=$(git rev-parse HEAD)
+
+git tag -a v"$version" "$git_commit_id" -m "Tagged $version"
+echo "TODO: git push --tags origin master"

--- a/scripts/release_new_version.sh
+++ b/scripts/release_new_version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -x
+
+./scripts/bump_build_number.sh
+version=$(./scripts/cli.sh version)
+./scripts/git_tag_release.sh "$version"

--- a/scripts/release_new_version.sh
+++ b/scripts/release_new_version.sh
@@ -3,3 +3,5 @@
 ./scripts/bump_build_number.sh
 version=$(./scripts/cli.sh version)
 ./scripts/git_tag_release.sh "$version"
+
+echo "TODO: ./scripts/build_signed_android_release.sh"

--- a/scripts/release_new_version.sh
+++ b/scripts/release_new_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -ex
 
 ./scripts/bump_build_number.sh
 version=$(./scripts/cli.sh version)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,18 @@
+import { Version } from './Version';
+
+declare var process: {
+    argv: string[];
+};
+
+if (process.argv.length > 2) {
+    switch (process.argv[2]) {
+        case 'version': {
+            console.log(Version);
+            break;
+        }
+        default: {
+            console.log('usage: cli [version]')
+            break;
+        }
+    }
+}


### PR DESCRIPTION
Added CLI option to be able to access code from the app. Also added some scripts that demonstrates the usage.

Currently the CLI may only be used to print the version, however later we can add extra functionality to make backups, test different versions, server side scripting etc.

I tested it somewhat, but not for edge-cases. Tomorrow I have to release a new version, because the previous failed to upload to the AppStore and cannot upload the current version again.